### PR TITLE
ISSUE 58: Update source tag to 1.4.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP Memcached 1.0, PHP APC 3.1.
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh-apache-php:centos-6-1.4.1
+FROM jdeathe/centos-ssh-apache-php:centos-6-1.4.2
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-apache-php-fcgi/issues/58
