### PR TITLE
ISSUE 78: Remove reference to mod_php requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ The following configuration files are required to run the application container 
 
 - [httpd/conf/httpd.conf](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/etc/services-config/httpd/conf/httpd.conf)
 - [httpd/conf.d/fcgid.conf](https://github.com/jdeathe/centos-ssh-apache-php-fgci/blob/centos-6/etc/services-config/httpd/conf.d/fcgid.conf)
-- [httpd/conf.d/php.conf](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/etc/services-config/httpd/conf.d/php.conf)
 - [httpd/conf.d/ssl.conf](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/etc/services-config/httpd/conf.d/ssl.conf)
 - [supervisor/supervisord.conf](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/etc/services-config/supervisor/supervisord.conf)
 


### PR DESCRIPTION
- Missed out this README change. This configuration file is not required by fcgid implementation and does not exist on the container image.

Relates to #78 
