### PR TITLE
CLOSES #130: Updates image source to 1.10.2.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+dist
+test
+LICENSE
+README-short.txt
+*.md
+!README.md
+**/*.mk
+**/Makefile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64, Apache 2.2, PHP-CGI 5.3 (FastCGI), PHP memcached 1.0, PHP APC 3.1.
 
+### 1.10.2 - Unreleased
+
+- Updates image source to [release 1.10.2](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.2).
+
 ### 1.10.1 - 2017-09-28
 
 - Updates image source to [release 1.10.1](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.1).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP Memcached 1.0, PHP APC 3.1.
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh-apache-php:1.10.1
+FROM jdeathe/centos-ssh-apache-php:1.10.2
 
 # -----------------------------------------------------------------------------
 # FastCGI support


### PR DESCRIPTION
Resolves #130 

- Updates image source to [release 1.10.2](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.2).