### PR TITLE
CLOSES #136: Updates upstream source to 1.10.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64, Apache 2.2, PHP-CGI 5.3 (FastCGI), PHP memcached 1.0, PHP APC 3.1.
 
+### 1.10.4 - Unreleased
+
+- Updates image source to [release 1.10.4](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.4).
+
 ### 1.10.3 - 2018-01-16
 
 - Updates image source to [release 1.10.3](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.3).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP Memcached 1.0, PHP APC 3.1.
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh-apache-php:1.10.3
+FROM jdeathe/centos-ssh-apache-php:1.10.4
 
 # -----------------------------------------------------------------------------
 # FastCGI support

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ The Apache ErrorLog can be defined using `APACHE_ERROR_LOG_LOCATION` to set a fi
 
 ```
 ...
-  --env "APACHE_CUSTOM_LOG_LOCATION=/var/log/httpd/error_log" \
-  --env "APACHE_CUSTOM_LOG_FORMAT=error" \
+  --env "APACHE_ERROR_LOG_LOCATION=/var/log/httpd/error_log" \
+  --env "APACHE_ERROR_LOG_FORMAT=error" \
 ...
 ```
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -686,6 +686,7 @@ function test_custom_configuration ()
 	local curl_session_name=""
 	local header_x_service_operating_mode=""
 	local header_x_service_uid=""
+	local is_up=""
 	local php_date_timezone=""
 	local protocol=""
 
@@ -2047,16 +2048,23 @@ function test_custom_configuration ()
 
 			# Healthcheck should fail unless running PHP-FPM without Apache.
 			it "Can disable httpd-bootstrap."
+				is_up="1"
+
 				docker ps \
-					--format "name=apache-php.pool-1.1.1" \
-				&> /dev/null \
-				&& docker top \
+					--quiet \
+					--filter "name=apache-php.pool-1.1.1" \
+					--filter "health=unhealthy" \
+				&> /dev/null
+				is_up="${?}"
+
+				docker top \
 					apache-php.pool-1.1.1 \
+				&> /dev/null \
 				| grep -qE '/usr/sbin/httpd(\.worker|\.event)? '
 
 				assert equal \
-					"${?}" \
-					"1"
+					"${is_up}:${?}" \
+					"0:1"
 			end
 
 			__terminate_container \
@@ -2073,17 +2081,22 @@ function test_custom_configuration ()
 			sleep ${STARTUP_TIME}
 
 			it "Can disable httpd-wrapper."
+				is_up="1"
+
 				docker ps \
-					--format "name=apache-php.pool-1.1.1" \
-					--format "health=healthy" \
-				&> /dev/null \
-				&& docker top \
+					--filter "name=apache-php.pool-1.1.1" \
+					--filter "health=healthy" \
+				&> /dev/null
+				is_up="${?}"
+
+				docker top \
 					apache-php.pool-1.1.1 \
+				&> /dev/null \
 				| grep -qE '/usr/sbin/httpd(\.worker|\.event)? '
 
 				assert equal \
-					"${?}" \
-					"1"
+					"${is_up}:${?}" \
+					"0:1"
 			end
 
 			__terminate_container \


### PR DESCRIPTION
CLOSES #136

- Updates image source to [release 1.10.4](https://github.com/jdeathe/centos-ssh-apache-php/releases/tag/1.10.4).