### PR TITLE
CLOSES #152: Updates source image to 2.4.1 + package updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, Zend Opcache 7.0.
 
+### 2.0.1 - Unreleased
+
+- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
+- Updates `httpd` packages to 2.4.6-88.
+- Updates `php` packages to 5.4.16-46.
+
 ### 2.0.0 - 2018-10-14
 
 - Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@
 # CentOS-7, Apache 2.4, PHP 5.4, PHP Memcached 2.2, Zend Opcache.
 # 
 # =============================================================================
-# FROM jdeathe/centos-ssh-apache-php:1.11.0
-FROM jdeathe/centos-ssh:2.4.0
+FROM jdeathe/centos-ssh:2.4.1
 
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"
@@ -21,11 +20,12 @@ RUN rpm --rebuilddb \
 		--disableplugin=fastestmirror \
 		elinks-0.12-0.37.pre6.el7 \
 		fcgi-2.4.0-25.el7 \
-		httpd-2.4.6-80.el7.centos.1 \
-		httpd-tools-2.4.6-80.el7.centos.1 \
+		httpd-2.4.6-88.el7.centos \
+		httpd-tools-2.4.6-88.el7.centos \
 		mod_fcgid-2.3.9-4.el7_4.1 \
-		mod_ssl-2.4.6-80.el7.centos.1 \
-		php-cli-5.4.16-45.el7 \
+		mod_ssl-2.4.6-88.el7.centos \
+		php-cli-5.4.16-46.el7 \
+		php-common-5.4.16-46.el7 \
 		php-pecl-zendopcache-7.0.5-2.el7 \
 		php-pecl-memcached-2.2.0-1.el7 \
 	&& yum versionlock add \


### PR DESCRIPTION
CLOSES #152

- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
- Updates `httpd` packages to 2.4.6-88.
- Updates `php` packages to 5.4.16-46.