### PR TITLE
CLOSES #175: Updates description metadata with redis version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, 
 ### 2.2.0 - Unreleased
 
 - Updates description in centos-ssh-apache-php-fcgi.register@.service.
+- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.
 - Removes unused `DOCKER_PORT_MAP_TCP_22` variable from environment includes.
 
 ### 2.1.0 - 2019-04-14

--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ jdeathe/centos-ssh-apache-php-fcgi:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-apache-php-fcgi" \
-	org.deathe.description="CentOS-7 7.5.1804 x86_64 - Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, Zend Opcache 7.0."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, PHP redis 2.2, Zend Opcache 7.0."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ centos-ssh-apache-php-fcgi
 ==========================
 
 Docker Image including:
-- CentOS-6 6.10 x86_64, Apache 2.2, PHP-CGI 5.3 (FastCGI), PHP memcached 1.0, PHP APC 3.1.
-- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, Zend Opcache 7.0.
+- CentOS-6 6.10 x86_64, Apache 2.2, PHP-CGI 5.3 (FastCGI), PHP memcached 1.0, PHP redis 2.2, PHP APC 3.1.
+- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-CGI 5.4 (FastCGI), PHP memcached 2.2, PHP redis 2.2, Zend Opcache 7.0.
 
 Apache PHP web server, loading only a minimal set of Apache modules by default. Supports custom configuration via environment variables.
 


### PR DESCRIPTION
CLOSES #175

- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.