### PR TITLE
Release changes for 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes.
 ### 1.13.2 - Unreleased
 
 - Adds PHP 5 applicable session settings into service configuration.
+- Adds configuration file replacement of placeholders for Xdebug's `DBGP_IDEKEY`.
 
 ### 1.13.1 - 2019-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Summary of release changes.
 
 ### 1.13.2 - Unreleased
 
+- Updates php-hello-world to [0.14.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.14.0).
 - Adds PHP 5 applicable session settings into service configuration.
 - Adds configuration file replacement of placeholders for Xdebug's `DBGP_IDEKEY`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Summary of release changes.
 
-### 1.13.2 - Unreleased
+### 1.13.2 - 2019-08-05
 
 - Updates php-hello-world to [0.14.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.14.0).
 - Adds PHP 5 applicable session settings into service configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes.
 
+### 1.13.2 - Unreleased
+
+- Adds PHP 5 applicable session settings into service configuration.
+
 ### 1.13.1 - 2019-07-28
 
 - Updates php-hello-world to [0.13.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.13.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM jdeathe/centos-ssh:1.11.0
 ARG PACKAGE_NAME="app"
 ARG PACKAGE_PATH="/opt/${PACKAGE_NAME}"
 ARG PACKAGE_RELEASE_VERSION="0.14.0"
-ARG RELEASE_VERSION="1.13.1"
+ARG RELEASE_VERSION="1.13.2"
 
 # ------------------------------------------------------------------------------
 # Base install of required packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM jdeathe/centos-ssh:1.11.0
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"
 ARG PACKAGE_PATH="/opt/${PACKAGE_NAME}"
-ARG PACKAGE_RELEASE_VERSION="0.13.0"
+ARG PACKAGE_RELEASE_VERSION="0.14.0"
 ARG RELEASE_VERSION="1.13.1"
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ADD src /
 # - Disable Apache default fcgid configuration; replaced with 00-fcgid.conf
 # - Disable the default SSL Virtual Host
 # - Disable SSL
-# - Add default PHP configuration overrides to 00-php.ini drop-in.
+# - Add default PHP configuration overrides to 00-php.ini drop-in
 # - APC configuration
 # - Replace placeholders with values in systemd service unit template
 # - Set permissions
@@ -159,6 +159,8 @@ RUN useradd -r -M -d /var/www/app -s /sbin/nologin app \
 		-e 's~^;?(realpath_cache_size( )?=).*$~\1\24096k~' \
 		-e 's~^;?(realpath_cache_ttl( )?=).*$~\1\2600~' \
 		-e 's~^;?(session.cookie_httponly( )?=).*$~\1\21~' \
+		-e 's~^;?(session.hash_bits_per_character( )?=).*$~\1\25~' \
+		-e 's~^;?(session.hash_function( )?=).*$~\1\2sha256~' \
 		-e 's~^;?(session.name( )?=).*$~\1\2"${PHP_OPTIONS_SESSION_NAME:-PHPSESSID}"~' \
 		-e 's~^;?(session.save_handler( )?=).*$~\1\2"${PHP_OPTIONS_SESSION_SAVE_HANDLER:-files}"~' \
 		-e 's~^;?(session.save_path( )?=).*$~\1\2"${PHP_OPTIONS_SESSION_SAVE_PATH:-/var/lib/php/session}"~' \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Tags and respective `Dockerfile` links
 
-- `centos-7`, `2.2.1` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php-fcgi/blob/centos-7/Dockerfile)
-- `centos-6`, `1.13.1` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php-fcgi/blob/centos-6/Dockerfile)
+- `centos-7`, `2.2.2` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php-fcgi/blob/centos-7/Dockerfile)
+- `centos-6`, `1.13.2` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php-fcgi/blob/centos-6/Dockerfile)
 
 ## Overview
 
@@ -25,7 +25,7 @@ $ docker run -d \
   --name apache-php.1 \
   -p 8080:80 \
   -e "APACHE_SERVER_NAME=app-1.local" \
-  jdeathe/centos-ssh-apache-php-fcgi:2.2.1
+  jdeathe/centos-ssh-apache-php-fcgi:2.2.2
 ```
 
 Go to `http://{{docker-host}}:8080` using a browser where `{{docker-host}}` is the host name of your docker server and, if all went well, you should see the "Hello, world!" page.
@@ -90,7 +90,7 @@ $ docker stop apache-php.1 && \
   --env "APACHE_SERVER_NAME=app-1.local" \
   --env "APACHE_SSL_PROTOCOL=All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1" \
   --env "PHP_OPTIONS_DATE_TIMEZONE=Europe/London" \
-  jdeathe/centos-ssh-apache-php-fcgi:2.2.1
+  jdeathe/centos-ssh-apache-php-fcgi:2.2.2
 ```
 
 #### Environment Variables
@@ -204,7 +204,7 @@ $ docker stop apache-php.1 && \
   --env "APACHE_SERVER_ALIAS=app-1" \
   --env "APACHE_SERVER_NAME=app-1.local" \
   --env "APACHE_MOD_SSL_ENABLED=true" \
-  jdeathe/centos-ssh-apache-php-fcgi:2.2.1
+  jdeathe/centos-ssh-apache-php-fcgi:2.2.2
 ```
 
 ##### APACHE_MPM

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -686,6 +686,11 @@ function __get_apache_server_version ()
 	printf -- '%s' "${semantic_version}"
 }
 
+function __get_dbgp_idekey ()
+{
+	printf -- '%s' "${DBGP_IDEKEY}"
+}
+
 function __get_details_ssl_certificate_fingerprint ()
 {
 	local -r digest="${1:-sha1}"
@@ -1719,6 +1724,7 @@ function main ()
 	local apache_ssl_protocol
 	local apache_system_user
 	local config_files
+	local dbgp_idekey
 	local details_modules_enabled_list
 	local details_ssl_certificate_fingerprint
 	local document_root
@@ -1814,6 +1820,9 @@ function main ()
 	)"
 	apache_system_user="$(
 		__get_apache_system_user
+	)"
+	dbgp_idekey="$(
+		__get_dbgp_idekey
 	)"
 	php_options_date_timezone="$(
 		__get_php_options_date_timezone
@@ -1966,6 +1975,7 @@ function main ()
 		-e "s~(\\$\{|\{\{)APACHE_SSL_CIPHER_SUITE(\}\}|(:-.+)?\})~${apache_ssl_cipher_suite}~g" \
 		-e "s~(\\$\{|\{\{)APACHE_SSL_PROTOCOL(\}\}|(:-.+)?\})~${apache_ssl_protocol}~g" \
 		-e "s~(\\$\{|\{\{)APACHE_SYSTEM_USER(\}\}|(:-.+)?\})~${apache_system_user}~g" \
+		-e "s~(\\$\{|\{\{)DBGP_IDEKEY(\}\}|(:-.+)?\})~${dbgp_idekey}~g" \
 		-e "s~(\\$\{|\{\{)PACKAGE_PATH(\}\}|(:-.+)?\})~${package_path}~g" \
 		-e "s~(\\$\{|\{\{)PHP_OPTIONS_DATE_TIMEZONE(\}\}|(:-.+)?\})~${php_options_date_timezone}~g" \
 		-e "s~(\\$\{|\{\{)PHP_OPTIONS_SESSION_NAME(\}\}|(:-.+)?\})~${php_options_session_name}~g" \


### PR DESCRIPTION
- Updates php-hello-world to [0.14.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.14.0).
- Adds PHP 5 applicable session settings into service configuration.
- Adds configuration file replacement of placeholders for Xdebug's `DBGP_IDEKEY`.