### PR TITLE
CLOSES #246: Removes PHP-FPM status handler from server-status drop-in config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Summary of release changes.
 - Adds Makefile target `logsdef` to handle deferred logs output within a target chain.
 - Adds `/docs` directory for supplementary documentation and simplify README.
 - Fixes validation failure of 0 second --timeout value in `test/health_status`.
+- Removes PHP-FPM status handler configuration from the Apache server-status drop-in.
 
 ### 2.2.2 - 2019-08-05
 

--- a/src/etc/httpd/conf.d/00-server-status.conf
+++ b/src/etc/httpd/conf.d/00-server-status.conf
@@ -1,25 +1,11 @@
-<IfVersion < 2.4>
-    <Location "/server-status">
-        SetHandler server-status
+<Location "/server-status">
+    SetHandler server-status
+    <IfVersion < 2.4>
         Order deny,allow
         Deny from all
         Allow from localhost 127.0.0.1
-    </Location>
-    <Location "/status">
-        SetHandler "proxy:unix:/run/php-fpm/${APACHE_RUN_USER}.sock|fcgi://localhost"
-        Order deny,allow
-        Deny from all
-        Allow from localhost 127.0.0.1
-    </Location>
-</IfVersion>
-
-<IfVersion >= 2.4>
-    <Location "/server-status">
-        SetHandler server-status
+    </IfVersion>
+    <IfVersion >= 2.4>
         Require host localhost 127.0.0.1
-    </Location>
-    <Location "/status">
-        SetHandler "proxy:unix:/run/php-fpm/${APACHE_RUN_USER}.sock|fcgi://localhost"
-        Require host localhost 127.0.0.1
-    </Location>
-</IfVersion>
+    </IfVersion>
+</Location>


### PR DESCRIPTION
CLOSES #246